### PR TITLE
ARCH-726 ci(dtrack): Choose version extraction method.

### DIFF
--- a/dtrack/sbom-gradle/action.yaml
+++ b/dtrack/sbom-gradle/action.yaml
@@ -25,6 +25,10 @@ inputs:
     description: 'Parent project version in Dependency track (Parent name is also required)'
     required: false
     default: ''
+  version:
+    description: 'A string value that will be set as version to dependency track'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -38,7 +42,11 @@ runs:
       id: vars
       run: |
         echo "PROJECT_NAME=$(./gradlew properties --no-daemon --console=plain -q | grep "^Root project" | awk '{printf $3}' | sed "s/'//g")" >> $GITHUB_OUTPUT
-        echo "PROJECT_VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}')" >> $GITHUB_OUTPUT
+        if [[ "${{ inputs.version }}" == "" ]]; then
+           echo "PROJECT_VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{printf $2}')" >> $GITHUB_OUTPUT
+        else
+           echo "PROJECT_VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+        fi
 
     - name: Upload to dependency track
       id: upload-to-dependency-track


### PR DESCRIPTION
For gradle projects that do not manage their version with gradle, we need a way to pass the version number to the sbom gha. This version will be set to the dependency track project.